### PR TITLE
Update openssl. Don't stop to pod2man warnings.

### DIFF
--- a/openssl/Buildfile
+++ b/openssl/Buildfile
@@ -3,10 +3,10 @@
 # License: OpenSSL
 
 name=openssl
-version=1.0.1f
+version=1.0.1g
 release=1
 source=(http://www.openssl.org/source/$name-$version.tar.gz
-        openssl-1.0.1-parallel-build.patch)
+	openssl-1.0.1-parallel-build.patch pod2man.patch)
 depends=zlib
 
 build() {
@@ -23,6 +23,8 @@ build() {
                threads \
                shared \
                linux-generic32
+
+  patch -p1 < $SRC/pod2man.patch
 
   make -j $JOBS
   make MANDIR=/usr/share/man MANSUFFIX=ssl install

--- a/openssl/pod2man.patch
+++ b/openssl/pod2man.patch
@@ -1,0 +1,13 @@
+*** a/Makefile	2014-04-22 15:08:15.770935188 +0300
+--- b/Makefile	2014-04-22 15:08:08.466935437 +0300
+***************
+*** 648,651 ****
+! 	@pod2man="`cd ./util; ./pod2mantest $(PERL)`"; \
+  	here="`pwd`"; \
+  	filecase=; \
+  	if [ "$(PLATFORM)" = "DJGPP" -o "$(PLATFORM)" = "Cygwin" -o "$(PLATFORM)" = "mingw" ]; then \
+--- 648,651 ----
+! 	@pod2man="`cd ./util; ./pod2mantest $(PERL)` -errors=stderr"; \
+  	here="`pwd`"; \
+  	filecase=; \
+  	if [ "$(PLATFORM)" = "DJGPP" -o "$(PLATFORM)" = "Cygwin" -o "$(PLATFORM)" = "mingw" ]; then \


### PR DESCRIPTION
Move forward from heardbleed version.
Ubuntu 14.04 pod2man seems to be more strict.

Signed-off-by: Jari Vanhala jari.vanhala@ixonos.com
