### PR TITLE
systemd: run libgcrypt-config from cross-compile enviroment

### DIFF
--- a/systemd/Buildfile
+++ b/systemd/Buildfile
@@ -31,6 +31,7 @@ build() {
                --disable-kdbus \
                --disable-selinux \
                --disable-pam \
+               --with-libgcrypt-prefix=$SYSROOT/usr \
                --disable-libcryptsetup \
                --disable-gtk-doc \
                --disable-dbus \


### PR DESCRIPTION
This makes configure using libgcrypt-config from cross-compile enviroment
instead of native enviroment.

Signed-off-by: Kalle Lampila kalle.lampila@ixonos.com
